### PR TITLE
Make colors more compliant with Neovim theme

### DIFF
--- a/dist/themes/rose-pine-dawn.tmTheme
+++ b/dist/themes/rose-pine-dawn.tmTheme
@@ -30,6 +30,8 @@
       <string>comment</string>
       <key>settings</key>
       <dict>
+        <key>fontStyle</key>
+        <string>italic</string>
         <key>foreground</key>
         <string>#797593</string>
       </dict>
@@ -38,7 +40,7 @@
       <key>name</key>
       <string>String</string>
       <key>scope</key>
-      <string>string</string>
+      <string>string, punctuation.definition.string</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
@@ -53,7 +55,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#907aa9</string>
+        <string>#ea9d34</string>
       </dict>
     </dict>
     <dict>
@@ -63,8 +65,10 @@
       <string>constant.language</string>
       <key>settings</key>
       <dict>
+        <key>fontStyle</key>
+        <string>bold</string>
         <key>foreground</key>
-        <string>#907aa9</string>
+        <string>#ea9d34</string>
       </dict>
     </dict>
     <dict>
@@ -75,7 +79,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#907aa9</string>
+        <string>#ea9d34</string>
       </dict>
     </dict>
     <dict>
@@ -86,9 +90,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>italic</string>
         <key>foreground</key>
-        <string>#d7827e</string>
+        <string>#575279</string>
       </dict>
     </dict>
     <dict>
@@ -99,7 +103,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#b4637a</string>
+        <string>#286983</string>
       </dict>
     </dict>
     <dict>
@@ -112,7 +116,7 @@
         <key>fontStyle</key>
         <string></string>
         <key>foreground</key>
-        <string>#b4637a</string>
+        <string>#56949f</string>
       </dict>
     </dict>
     <dict>
@@ -123,7 +127,7 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string>italic</string>
+        <string></string>
         <key>foreground</key>
         <string>#56949f</string>
       </dict>
@@ -136,7 +140,7 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string> bold</string>
+        <string>bold</string>
         <key>foreground</key>
         <string>#286983</string>
       </dict>
@@ -162,9 +166,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>italic</string>
         <key>foreground</key>
-        <string>#286983</string>
+        <string>#d7827e</string>
       </dict>
     </dict>
     <dict>
@@ -175,9 +179,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string>italic</string>
+        <string></string>
         <key>foreground</key>
-        <string>#ea9d34</string>
+        <string>#907aa9</string>
       </dict>
     </dict>
     <dict>
@@ -188,9 +192,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
         <key>foreground</key>
-        <string>#b4637a</string>
+        <string>#286983</string>
       </dict>
     </dict>
     <dict>
@@ -203,7 +207,7 @@
         <key>fontStyle</key>
         <string></string>
         <key>foreground</key>
-        <string>#286983</string>
+        <string>#907aa9</string>
       </dict>
     </dict>
     <dict>
@@ -214,9 +218,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
         <key>foreground</key>
-        <string>#56949f</string>
+        <string>#d7827e</string>
       </dict>
     </dict>
     <dict>
@@ -227,9 +231,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
         <key>foreground</key>
-        <string>#56949f</string>
+        <string>#ea9d34</string>
       </dict>
     </dict>
     <dict>
@@ -240,7 +244,7 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string>italic</string>
+        <string>bold</string>
         <key>foreground</key>
         <string>#56949f</string>
       </dict>
@@ -253,7 +257,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
+        <key>foreground</key>
+        <string>#b4637a</string>
       </dict>
     </dict>
     <dict>
@@ -285,15 +291,13 @@
       </dict>
     </dict>
   </array>
-  <key>uuid</key>
-  <string>dac29768-bcff-4df3-936c-88c7540d550d</string>
   <key>colorSpaceName</key>
   <string>sRGB</string>
   <key>semanticClass</key>
-  <string>theme.light.rosé_pine-dawn</string>
+  <string>theme.light.rosé-pine-dawn</string>
   <key>author</key>
-  <string>oplik0</string>
+  <string>arrrgi</string>
   <key>comment</key>
-  <string>soho vibes - modified from the sublime text theme by ThatOneCalculator</string>
+  <string>All natural pine, faux fur and a bit of soho vibes for the classy minimalist</string>
 </dict>
 </plist>

--- a/dist/themes/rose-pine-dawn.tmTheme
+++ b/dist/themes/rose-pine-dawn.tmTheme
@@ -290,6 +290,17 @@
         <string>#575279</string>
       </dict>
     </dict>
+    <dict>
+      <key>name</key>
+      <string>Punctuation, Operators</string>
+      <key>scope</key>
+      <string>punctuation, keyword.operator</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#797593</string>
+      </dict>
+    </dict>
   </array>
   <key>colorSpaceName</key>
   <string>sRGB</string>

--- a/dist/themes/rose-pine-moon.tmTheme
+++ b/dist/themes/rose-pine-moon.tmTheme
@@ -30,6 +30,8 @@
       <string>comment</string>
       <key>settings</key>
       <dict>
+        <key>fontStyle</key>
+        <string>italic</string>
         <key>foreground</key>
         <string>#908caa</string>
       </dict>
@@ -38,7 +40,7 @@
       <key>name</key>
       <string>String</string>
       <key>scope</key>
-      <string>string</string>
+      <string>string, punctuation.definition.string</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
@@ -53,7 +55,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#c4a7e7</string>
+        <string>#f6c177</string>
       </dict>
     </dict>
     <dict>
@@ -63,8 +65,10 @@
       <string>constant.language</string>
       <key>settings</key>
       <dict>
+        <key>fontStyle</key>
+        <string>bold</string>
         <key>foreground</key>
-        <string>#c4a7e7</string>
+        <string>#f6c177</string>
       </dict>
     </dict>
     <dict>
@@ -75,7 +79,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#c4a7e7</string>
+        <string>#f6c177</string>
       </dict>
     </dict>
     <dict>
@@ -86,9 +90,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>italic</string>
         <key>foreground</key>
-        <string>#ea9a97</string>
+        <string>#e0def4</string>
       </dict>
     </dict>
     <dict>
@@ -99,7 +103,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#eb6f92</string>
+        <string>#3e8fb0</string>
       </dict>
     </dict>
     <dict>
@@ -112,7 +116,7 @@
         <key>fontStyle</key>
         <string></string>
         <key>foreground</key>
-        <string>#eb6f92</string>
+        <string>#9ccfd8</string>
       </dict>
     </dict>
     <dict>
@@ -123,7 +127,7 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string>italic</string>
+        <string></string>
         <key>foreground</key>
         <string>#9ccfd8</string>
       </dict>
@@ -136,7 +140,7 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string> bold</string>
+        <string>bold</string>
         <key>foreground</key>
         <string>#3e8fb0</string>
       </dict>
@@ -162,9 +166,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>italic</string>
         <key>foreground</key>
-        <string>#3e8fb0</string>
+        <string>#ea9a97</string>
       </dict>
     </dict>
     <dict>
@@ -175,9 +179,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string>italic</string>
+        <string></string>
         <key>foreground</key>
-        <string>#f6c177</string>
+        <string>#c4a7e7</string>
       </dict>
     </dict>
     <dict>
@@ -188,9 +192,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
         <key>foreground</key>
-        <string>#eb6f92</string>
+        <string>#3e8fb0</string>
       </dict>
     </dict>
     <dict>
@@ -203,7 +207,7 @@
         <key>fontStyle</key>
         <string></string>
         <key>foreground</key>
-        <string>#3e8fb0</string>
+        <string>#c4a7e7</string>
       </dict>
     </dict>
     <dict>
@@ -214,9 +218,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
         <key>foreground</key>
-        <string>#9ccfd8</string>
+        <string>#ea9a97</string>
       </dict>
     </dict>
     <dict>
@@ -227,9 +231,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
         <key>foreground</key>
-        <string>#9ccfd8</string>
+        <string>#f6c177</string>
       </dict>
     </dict>
     <dict>
@@ -240,7 +244,7 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string>italic</string>
+        <string>bold</string>
         <key>foreground</key>
         <string>#9ccfd8</string>
       </dict>
@@ -253,7 +257,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
+        <key>foreground</key>
+        <string>#eb6f92</string>
       </dict>
     </dict>
     <dict>
@@ -285,15 +291,13 @@
       </dict>
     </dict>
   </array>
-  <key>uuid</key>
-  <string>a65f621e-b84b-48fb-afec-e5c085e8debf</string>
   <key>colorSpaceName</key>
   <string>sRGB</string>
   <key>semanticClass</key>
-  <string>theme.dark.rosé_pine-moon</string>
+  <string>theme.dark.rosé-pine-moon</string>
   <key>author</key>
-  <string>oplik0</string>
+  <string>arrrgi</string>
   <key>comment</key>
-  <string>soho vibes - modified from the sublime text theme by ThatOneCalculator</string>
+  <string>All natural pine, faux fur and a bit of soho vibes for the classy minimalist</string>
 </dict>
 </plist>

--- a/dist/themes/rose-pine-moon.tmTheme
+++ b/dist/themes/rose-pine-moon.tmTheme
@@ -290,6 +290,17 @@
         <string>#e0def4</string>
       </dict>
     </dict>
+    <dict>
+      <key>name</key>
+      <string>Punctuation, Operators</string>
+      <key>scope</key>
+      <string>punctuation, keyword.operator</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#908caa</string>
+      </dict>
+    </dict>
   </array>
   <key>colorSpaceName</key>
   <string>sRGB</string>

--- a/dist/themes/rose-pine.tmTheme
+++ b/dist/themes/rose-pine.tmTheme
@@ -30,6 +30,8 @@
       <string>comment</string>
       <key>settings</key>
       <dict>
+        <key>fontStyle</key>
+        <string>italic</string>
         <key>foreground</key>
         <string>#908caa</string>
       </dict>
@@ -38,7 +40,7 @@
       <key>name</key>
       <string>String</string>
       <key>scope</key>
-      <string>string</string>
+      <string>string, punctuation.definition.string</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
@@ -53,7 +55,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#c4a7e7</string>
+        <string>#f6c177</string>
       </dict>
     </dict>
     <dict>
@@ -63,8 +65,10 @@
       <string>constant.language</string>
       <key>settings</key>
       <dict>
+        <key>fontStyle</key>
+        <string>bold</string>
         <key>foreground</key>
-        <string>#c4a7e7</string>
+        <string>#f6c177</string>
       </dict>
     </dict>
     <dict>
@@ -75,7 +79,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#c4a7e7</string>
+        <string>#f6c177</string>
       </dict>
     </dict>
     <dict>
@@ -86,9 +90,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>italic</string>
         <key>foreground</key>
-        <string>#ebbcba</string>
+        <string>#e0def4</string>
       </dict>
     </dict>
     <dict>
@@ -99,7 +103,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#eb6f92</string>
+        <string>#31748f</string>
       </dict>
     </dict>
     <dict>
@@ -112,7 +116,7 @@
         <key>fontStyle</key>
         <string></string>
         <key>foreground</key>
-        <string>#eb6f92</string>
+        <string>#9ccfd8</string>
       </dict>
     </dict>
     <dict>
@@ -123,7 +127,7 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string>italic</string>
+        <string></string>
         <key>foreground</key>
         <string>#9ccfd8</string>
       </dict>
@@ -136,7 +140,7 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string> bold</string>
+        <string>bold</string>
         <key>foreground</key>
         <string>#31748f</string>
       </dict>
@@ -162,9 +166,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>italic</string>
         <key>foreground</key>
-        <string>#31748f</string>
+        <string>#ebbcba</string>
       </dict>
     </dict>
     <dict>
@@ -175,9 +179,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string>italic</string>
+        <string></string>
         <key>foreground</key>
-        <string>#f6c177</string>
+        <string>#c4a7e7</string>
       </dict>
     </dict>
     <dict>
@@ -188,9 +192,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
         <key>foreground</key>
-        <string>#eb6f92</string>
+        <string>#31748f</string>
       </dict>
     </dict>
     <dict>
@@ -203,7 +207,7 @@
         <key>fontStyle</key>
         <string></string>
         <key>foreground</key>
-        <string>#31748f</string>
+        <string>#c4a7e7</string>
       </dict>
     </dict>
     <dict>
@@ -214,9 +218,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
         <key>foreground</key>
-        <string>#9ccfd8</string>
+        <string>#ebbcba</string>
       </dict>
     </dict>
     <dict>
@@ -227,9 +231,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
         <key>foreground</key>
-        <string>#9ccfd8</string>
+        <string>#f6c177</string>
       </dict>
     </dict>
     <dict>
@@ -240,7 +244,7 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string>italic</string>
+        <string>bold</string>
         <key>foreground</key>
         <string>#9ccfd8</string>
       </dict>
@@ -253,7 +257,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
+        <key>foreground</key>
+        <string>#eb6f92</string>
       </dict>
     </dict>
     <dict>
@@ -285,15 +291,13 @@
       </dict>
     </dict>
   </array>
-  <key>uuid</key>
-  <string>c3af112c-80e3-45fe-8890-43ca225fda21</string>
   <key>colorSpaceName</key>
   <string>sRGB</string>
   <key>semanticClass</key>
-  <string>theme.dark.rosé_pine</string>
+  <string>theme.dark.rosé-pine</string>
   <key>author</key>
-  <string>oplik0</string>
+  <string>arrrgi</string>
   <key>comment</key>
-  <string>soho vibes - modified from the sublime text theme by ThatOneCalculator</string>
+  <string>All natural pine, faux fur and a bit of soho vibes for the classy minimalist</string>
 </dict>
 </plist>

--- a/dist/themes/rose-pine.tmTheme
+++ b/dist/themes/rose-pine.tmTheme
@@ -290,6 +290,17 @@
         <string>#e0def4</string>
       </dict>
     </dict>
+    <dict>
+      <key>name</key>
+      <string>Punctuation, Operators</string>
+      <key>scope</key>
+      <string>punctuation, keyword.operator</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#908caa</string>
+      </dict>
+    </dict>
   </array>
   <key>colorSpaceName</key>
   <string>sRGB</string>

--- a/src/rose-pine-template.tmTheme
+++ b/src/rose-pine-template.tmTheme
@@ -30,6 +30,8 @@
       <string>comment</string>
       <key>settings</key>
       <dict>
+        <key>fontStyle</key>
+        <string>italic</string>
         <key>foreground</key>
         <string>$subtle</string>
       </dict>
@@ -38,7 +40,7 @@
       <key>name</key>
       <string>String</string>
       <key>scope</key>
-      <string>string</string>
+      <string>string, punctuation.definition.string</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
@@ -53,7 +55,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>$iris</string>
+        <string>$gold</string>
       </dict>
     </dict>
     <dict>
@@ -63,8 +65,10 @@
       <string>constant.language</string>
       <key>settings</key>
       <dict>
+        <key>fontStyle</key>
+        <string>bold</string>
         <key>foreground</key>
-        <string>$iris</string>
+        <string>$gold</string>
       </dict>
     </dict>
     <dict>
@@ -75,7 +79,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>$iris</string>
+        <string>$gold</string>
       </dict>
     </dict>
     <dict>
@@ -86,9 +90,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>italic</string>
         <key>foreground</key>
-        <string>$rose</string>
+        <string>$text</string>
       </dict>
     </dict>
     <dict>
@@ -99,7 +103,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>$love</string>
+        <string>$pine</string>
       </dict>
     </dict>
     <dict>
@@ -112,7 +116,7 @@
         <key>fontStyle</key>
         <string></string>
         <key>foreground</key>
-        <string>$love</string>
+        <string>$foam</string>
       </dict>
     </dict>
     <dict>
@@ -123,7 +127,7 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string>italic</string>
+        <string></string>
         <key>foreground</key>
         <string>$foam</string>
       </dict>
@@ -136,7 +140,7 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string> bold</string>
+        <string>bold</string>
         <key>foreground</key>
         <string>$pine</string>
       </dict>
@@ -162,9 +166,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>italic</string>
         <key>foreground</key>
-        <string>$pine</string>
+        <string>$rose</string>
       </dict>
     </dict>
     <dict>
@@ -175,9 +179,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string>italic</string>
+        <string></string>
         <key>foreground</key>
-        <string>$gold</string>
+        <string>$iris</string>
       </dict>
     </dict>
     <dict>
@@ -188,9 +192,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
         <key>foreground</key>
-        <string>$love</string>
+        <string>$pine</string>
       </dict>
     </dict>
     <dict>
@@ -203,7 +207,7 @@
         <key>fontStyle</key>
         <string></string>
         <key>foreground</key>
-        <string>$pine</string>
+        <string>$iris</string>
       </dict>
     </dict>
     <dict>
@@ -214,9 +218,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
         <key>foreground</key>
-        <string>$foam</string>
+        <string>$rose</string>
       </dict>
     </dict>
     <dict>
@@ -227,9 +231,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
         <key>foreground</key>
-        <string>$foam</string>
+        <string>$gold</string>
       </dict>
     </dict>
     <dict>
@@ -240,7 +244,7 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string>italic</string>
+        <string>bold</string>
         <key>foreground</key>
         <string>$foam</string>
       </dict>
@@ -253,7 +257,9 @@
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
-        <string></string>
+        <string>bold</string>
+        <key>foreground</key>
+        <string>$love</string>
       </dict>
     </dict>
     <dict>

--- a/src/rose-pine-template.tmTheme
+++ b/src/rose-pine-template.tmTheme
@@ -290,6 +290,17 @@
         <string>$text</string>
       </dict>
     </dict>
+    <dict>
+      <key>name</key>
+      <string>Punctuation, Operators</string>
+      <key>scope</key>
+      <string>punctuation, keyword.operator</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>$subtle</string>
+      </dict>
+    </dict>
   </array>
   <key>colorSpaceName</key>
   <string>sRGB</string>


### PR DESCRIPTION
According to #1, I've tried my best to make this theme more compliant with Neovim theme colors. It's not perfect yet, some polishing required. However, I think it's better to merge this now and improve it later. I'm not very familiar with tmTheme format, so I need to study more first, before I'll be able to finish this.

## Before
![image](https://github.com/user-attachments/assets/a3676423-585e-4e90-9019-bfca1499be34)

## After
![image](https://github.com/user-attachments/assets/c63adca6-3473-4c77-bce9-9d11d0eaca2e)