### PR TITLE
Add manpage syntax highlighting support

### DIFF
--- a/dist/rose-pine-dawn.tmTheme
+++ b/dist/rose-pine-dawn.tmTheme
@@ -136,13 +136,26 @@
       <key>name</key>
       <string>Class name</string>
       <key>scope</key>
-      <string>entity.name.class</string>
+      <string>entity.name.class, entity.name</string>
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
         <string>bold</string>
         <key>foreground</key>
         <string>#286983</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Headings</string>
+      <key>scope</key>
+      <string>markup.heading</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string>bold</string>
+        <key>foreground</key>
+        <string>#d7827e</string>
       </dict>
     </dict>
     <dict>

--- a/dist/rose-pine-moon.tmTheme
+++ b/dist/rose-pine-moon.tmTheme
@@ -136,13 +136,26 @@
       <key>name</key>
       <string>Class name</string>
       <key>scope</key>
-      <string>entity.name.class</string>
+      <string>entity.name.class, entity.name</string>
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
         <string>bold</string>
         <key>foreground</key>
         <string>#3e8fb0</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Headings</string>
+      <key>scope</key>
+      <string>markup.heading</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string>bold</string>
+        <key>foreground</key>
+        <string>#ea9a97</string>
       </dict>
     </dict>
     <dict>

--- a/dist/rose-pine.tmTheme
+++ b/dist/rose-pine.tmTheme
@@ -136,13 +136,26 @@
       <key>name</key>
       <string>Class name</string>
       <key>scope</key>
-      <string>entity.name.class</string>
+      <string>entity.name.class, entity.name</string>
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
         <string>bold</string>
         <key>foreground</key>
         <string>#31748f</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Headings</string>
+      <key>scope</key>
+      <string>markup.heading</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string>bold</string>
+        <key>foreground</key>
+        <string>#ebbcba</string>
       </dict>
     </dict>
     <dict>

--- a/templates/template.tmTheme
+++ b/templates/template.tmTheme
@@ -136,13 +136,26 @@
       <key>name</key>
       <string>Class name</string>
       <key>scope</key>
-      <string>entity.name.class</string>
+      <string>entity.name.class, entity.name</string>
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
         <string>bold</string>
         <key>foreground</key>
         <string>$pine</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Headings</string>
+      <key>scope</key>
+      <string>markup.heading</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string>bold</string>
+        <key>foreground</key>
+        <string>$rose</string>
       </dict>
     </dict>
     <dict>


### PR DESCRIPTION
Man pages rendered via `bat -lman` lack syntax highlighting because the theme is missing scopes that bat's man page syntax definition emits.

This adds:
- `entity.name` to the class name rule — colors bold command/function names
- `markup.heading` as a new rule — styles section headers (NAME, SYNOPSIS, etc.)

Equivalent fixes were applied to bat's bundled themes in sharkdp/bat#2994.